### PR TITLE
Fix permission wireshark

### DIFF
--- a/docs/code-overview/code-debugging.md
+++ b/docs/code-overview/code-debugging.md
@@ -99,6 +99,10 @@ Obs: Do the same for the other NF components. All the components are in `~/my5G-
     ```bash
     # stop all running NFs
     cd ~/my5G-core
+    
+    # fix wireshark permission
+    sudo dpkg-reconfigure wireshark-common #Select "Yes"
+    chmod +x /usr/bin/dumpcap
 
     # start wireshark
     wireshark -kni any --display-filter pfcp &

--- a/docs/code-overview/code-debugging.md
+++ b/docs/code-overview/code-debugging.md
@@ -101,8 +101,8 @@ Obs: Do the same for the other NF components. All the components are in `~/my5G-
     cd ~/my5G-core
     
     # fix wireshark permission
-    sudo dpkg-reconfigure wireshark-common #Select "Yes"
-    chmod +x /usr/bin/dumpcap
+    sudo usermod -a -G wireshark $USER
+    sudo chmod +x /usr/bin/dumpcap
 
     # start wireshark
     wireshark -kni any --display-filter pfcp &


### PR DESCRIPTION
Para o comando **wireshark -kni any --display-filter pfcp &**  inicializar sem erro é necessário dar permissão para usuário não-root capturar tráfego pelo wireshark e conceder permissão de execução para o processo /usr/bin/dumpcap.